### PR TITLE
remove mentions of drop-in

### DIFF
--- a/vip-jetpack-sync-cron/README.md
+++ b/vip-jetpack-sync-cron/README.md
@@ -1,2 +1,2 @@
 # VIP Jetpack Sync Cron
-This drop-in plugin ensures that Jetpack only syncs on the dedicated cron task, as Jetpack Sync piggybacks on various cron/API requests causing slowdowns on the shutdown hook.
+This plugin ensures that Jetpack only syncs on the dedicated cron task, as Jetpack Sync piggybacks on various cron/API requests causing slowdowns on the shutdown hook.

--- a/vip-jetpack-sync-cron/vip-jetpack-sync-cron.php
+++ b/vip-jetpack-sync-cron/vip-jetpack-sync-cron.php
@@ -1,10 +1,10 @@
-<?php 
+<?php
 
 /*
 Plugin Name: VIP Jetpack Sync Cron
-Description: This drop-in plugin ensures that Jetpack only syncs on the dedicated cron task.
+Description: This plugin ensures that Jetpack only syncs on the dedicated cron task.
 Version: 2.0
-Author: Rebecca Hum, Automattic 
+Author: Rebecca Hum, Automattic
 */
 
 use Automattic\Jetpack\Sync\Actions;
@@ -19,7 +19,7 @@ class VIP_Jetpack_Sync_Cron {
 
 	/**
 	 * Initiate an instance of this class if one doesn't exist already.
-	 * 
+	 *
 	 * @return VIP_Jetpack_Sync_Cron instance
 	 */
 	static public function init() {
@@ -42,7 +42,7 @@ class VIP_Jetpack_Sync_Cron {
 
 	/**
 	 * Class constructor for hooking actions/filters.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function __construct() {
@@ -54,7 +54,7 @@ class VIP_Jetpack_Sync_Cron {
 
 	/**
 	 * Filter to add custom interval to schedule.
-	 * 
+	 *
 	 * @param array  $schedules
 	 */
 	public function jp_sync_cron_schedule_interval( $schedules ) {
@@ -62,13 +62,13 @@ class VIP_Jetpack_Sync_Cron {
 		    'interval' => 60,
 		    'display'  => esc_html__( 'Every minute' ),
 		];
-		
+
 		return $schedules;
 	}
 
 	/**
 	 * Filter to return custom cron interval name.
-	 * 
+	 *
 	 * @param string  $incremental_sync_cron_schedule
 	 */
 	public function filter_jetpack_sync_interval() {


### PR DESCRIPTION
I'm 99% sure drop-in plugins land in /wp-content/ and
replace core functionality. the verbiage of this being a dropin plugin had me a bit confused

see https://kraft.blog/2018/05/wordpress-drop-in-plugins/